### PR TITLE
optionally validate headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## 0.1.4-dev
+ - add `headers` parameter to `Validate` and `header_is_set()` and `valid_header_value()` helper functions; optionally validate headers from `validate_and_load_static_assets()`
 
 ## 0.1.1, 0.1.2, 0.1.3 July 16, 2021
- - introduce `load_static_elements`, `valid_text`, `valid_title`, `validate_and_load_static_assets`, and `Validate`; document
+ - introduce `load_static_elements()`, `valid_text()`, `valid_title()`, `validate_and_load_static_assets()`, and `Validate`; document
  - enable CI
  - improve documentation; add CHANGELOG

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,6 @@ license = "Apache-2.0"
 
 [dependencies]
 goose = "0.12"
+log = "0.4"
 regex = "1.5"
+reqwest = "0.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 //! [`Goose`](https://docs.rs/goose) load tests.
 use goose::goose::GooseResponse;
 use goose::prelude::*;
+use log::info;
+use reqwest::header::HeaderMap;
 
 use regex::Regex;
 
@@ -21,8 +23,11 @@ use regex::Regex;
 ///         title: Some("my page"),
 ///         // Be sure both of the following strings are found on the page.
 ///         texts: vec!["foo", r#"<a href="bar">"#],
+///         // Don't do any validation of the headers.
+///         headers: vec![],
 ///     };
 /// }
+#[derive(Clone, Debug)]
 pub struct Validate<'a> {
     /// If provided, validate the response status code.
     pub status: Option<u16>,
@@ -30,6 +35,31 @@ pub struct Validate<'a> {
     pub title: Option<&'a str>,
     /// If provided, validate that the provided texts are found on the page.
     pub texts: Vec<&'a str>,
+    /// If provided, validate that the provided headers were set in the HTTP response.
+    pub headers: Vec<&'a Header<'a>>,
+}
+
+/// Used to validate that headers are included in the server response.
+///
+/// # Example
+/// ```rust
+/// use goose_eggs::Header;
+///
+/// fn example() {
+///     let _cookie = Header {
+///         // Validate that the "x-varnish" header is set.
+///         name: "x-varnish",
+///         // Don't further validate the contents of the header.
+///         value: None,
+///     };
+/// }
+
+#[derive(Clone, Debug)]
+pub struct Header<'a> {
+    /// The name of the header to validate, required.
+    pub name: &'a str,
+    /// The value of the header to validate, optional.
+    pub value: Option<&'a str>,
 }
 
 /// Returns a [`bool`] indicating whether or not the title (case insensitive) is
@@ -162,6 +192,124 @@ pub fn valid_text(html: &str, text: &str) -> bool {
     html.contains(text)
 }
 
+/// Returns a [`bool`] indicating whether or not a header was set in the server Response.
+///
+/// Returns [`true`] if the expected header was set, otherwise returns [`false`].
+///
+/// While you can invoke this function directly, it's generally preferred to invoke
+/// [`validate_and_load_static_assets`] which in turn invokes this function.
+///
+/// # Example
+/// ```rust
+/// use goose::prelude::*;
+/// use goose_eggs::{header_is_set, Header};
+///
+/// task!(validate_header).set_on_start();
+///
+/// async fn validate_header(user: &GooseUser) -> GooseTaskResult {
+///     let mut goose = user.get("/").await?;
+///
+///     match goose.response {
+///         Ok(response) => {
+///             // Copy the headers so we have them for logging if there are errors.
+///             let headers = &response.headers().clone();
+///             if !header_is_set(headers, &Header{ name: "server", value: None }) {
+///                 return user.set_failure(
+///                     &format!("{}: header not found: {}", goose.request.url, "server"),
+///                     &mut goose.request,
+///                     Some(&headers),
+///                     None,
+///                 );
+///             }
+///         }
+///         Err(e) => {
+///             return user.set_failure(
+///                 &format!("{}: no response from server: {}", goose.request.url, e),
+///                 &mut goose.request,
+///                 None,
+///                 None,
+///             );
+///         }
+///     }
+///
+///     Ok(())
+/// }
+/// ```
+pub fn header_is_set(headers: &HeaderMap, header: &Header) -> bool {
+    headers.contains_key(header.name)
+}
+
+/// Returns a [`bool`] indicating whether or not a header contains an expected value.
+///
+/// Returns [`true`] if the expected value was found, otherwise returns [`false`].
+///
+/// While you can invoke this function directly, it's generally preferred to invoke
+/// [`validate_and_load_static_assets`] which in turn invokes this function.
+///
+/// # Example
+/// ```rust
+/// use goose::prelude::*;
+/// use goose_eggs::{valid_header_value, Header};
+///
+/// task!(validate_header_value).set_on_start();
+///
+/// async fn validate_header_value(user: &GooseUser) -> GooseTaskResult {
+///     let mut goose = user.get("/").await?;
+///
+///     match goose.response {
+///         Ok(response) => {
+///             // Copy the headers so we have them for logging if there are errors.
+///             let headers = &response.headers().clone();
+///             if !valid_header_value(headers, &Header{ name: "server", value: Some("nginx") }) {
+///                 return user.set_failure(
+///                     &format!("{}: server header value not correct: {}", goose.request.url, "nginx"),
+///                     &mut goose.request,
+///                     Some(&headers),
+///                     None,
+///                 );
+///             }
+///         }
+///         Err(e) => {
+///             return user.set_failure(
+///                 &format!("{}: no response from server: {}", goose.request.url, e),
+///                 &mut goose.request,
+///                 None,
+///                 None,
+///             );
+///         }
+///     }
+///
+///     Ok(())
+/// }
+/// ```
+pub fn valid_header_value(headers: &HeaderMap, header: &Header) -> bool {
+    if header_is_set(headers, header) {
+        if let Some(value_to_validate) = header.value {
+            let header_value = match headers.get(header.name) {
+                // Extract the value of the header and try to convert to a &str.
+                Some(v) => v.to_str().unwrap_or(""),
+                None => "",
+            };
+            // Check if the desired value is in the header.
+            if header_value.contains(value_to_validate) {
+                true
+            } else {
+                // Provide some extra debug.
+                info!(
+                    r#"header does not contain expected value: "{}: {}""#,
+                    header.name, header_value
+                );
+                false
+            }
+        } else {
+            false
+        }
+    } else {
+        info!("header ({}) not set", header.name);
+        false
+    }
+}
+
 /// Extract and load all local static elements from the the provided html.
 ///
 /// While you can invoke this function directly, it's generally preferred to invoke
@@ -250,14 +398,16 @@ pub async fn load_static_elements(user: &GooseUser, html: &str) {
 ///     validate_and_load_static_assets(
 ///         user,
 ///         goose,
-///         Some(&Validate {
+///         &Validate {
 ///             // Don't do any extra validation of the status code.
 ///             status: None,
 ///             // Be sure the expected title is on the page.
 ///             title: Some("my page"),
 ///             // Be sure both of the following strings are found on the page.
 ///             texts: vec!["foo", r#"<a href="bar">"#],
-///         }),
+///             // Don't do any validateion of headers.
+///             headers: vec![],
+///         },
 ///     ).await?;
 ///
 ///     Ok(())
@@ -266,7 +416,7 @@ pub async fn load_static_elements(user: &GooseUser, html: &str) {
 pub async fn validate_and_load_static_assets<'a>(
     user: &GooseUser,
     mut goose: GooseResponse,
-    validate: Option<&'a Validate<'a>>,
+    validate: &'a Validate<'a>,
 ) -> GooseTaskResult {
     match goose.response {
         Ok(response) => {
@@ -275,39 +425,61 @@ pub async fn validate_and_load_static_assets<'a>(
             let response_status = response.status();
             match response.text().await {
                 Ok(html) => {
-                    if let Some(v) = validate {
-                        // Validate status code if defined.
-                        if let Some(status) = v.status {
-                            if response_status != status {
+                    // Validate status code if defined.
+                    if let Some(status) = validate.status {
+                        if response_status != status {
+                            return user.set_failure(
+                                &format!(
+                                    "{}: response status != {}]: {}",
+                                    goose.request.url, status, response_status
+                                ),
+                                &mut goose.request,
+                                Some(&headers),
+                                Some(&html),
+                            );
+                        }
+                    }
+                    // Validate title if defined.
+                    if let Some(title) = validate.title {
+                        if !valid_title(&html, &title) {
+                            return user.set_failure(
+                                &format!("{}: title not found: {}", goose.request.url, title),
+                                &mut goose.request,
+                                Some(&headers),
+                                Some(&html),
+                            );
+                        }
+                    }
+                    // Validate texts in body if defined.
+                    for text in &validate.texts {
+                        if !valid_text(&html, text) {
+                            return user.set_failure(
+                                &format!("{}: text not found on page: {}", goose.request.url, text),
+                                &mut goose.request,
+                                Some(&headers),
+                                Some(&html),
+                            );
+                        }
+                    }
+                    // Validate headers if defined.
+                    for header in &validate.headers {
+                        if !header_is_set(headers, header) {
+                            return user.set_failure(
+                                &format!(
+                                    "{}: header not included in response: {:?}",
+                                    goose.request.url, header
+                                ),
+                                &mut goose.request,
+                                Some(&headers),
+                                Some(&html),
+                            );
+                        }
+                        if let Some(h) = header.value {
+                            if !valid_header_value(headers, header) {
                                 return user.set_failure(
                                     &format!(
-                                        "{}: response status != {}]: {}",
-                                        goose.request.url, status, response_status
-                                    ),
-                                    &mut goose.request,
-                                    Some(&headers),
-                                    Some(&html),
-                                );
-                            }
-                        }
-                        // Validate title if defined.
-                        if let Some(title) = v.title {
-                            if !valid_title(&html, &title) {
-                                return user.set_failure(
-                                    &format!("{}: title not found: {}", goose.request.url, title),
-                                    &mut goose.request,
-                                    Some(&headers),
-                                    Some(&html),
-                                );
-                            }
-                        }
-                        // Validate texts in body if defined.
-                        for text in &v.texts {
-                            if !valid_text(&html, text) {
-                                return user.set_failure(
-                                    &format!(
-                                        "{}: text not found on page: {}",
-                                        goose.request.url, text
+                                        "{}: header does not contain expected value: {:?}",
+                                        goose.request.url, h
                                     ),
                                     &mut goose.request,
                                     Some(&headers),


### PR DESCRIPTION
 - add `headers` parameter to `Validate` and `header_is_set()` and `valid_header_value()` helper functions; optionally validate headers from `validate_and_load_static_assets()`

Can simply validate that a header is set, or validate that a header is set to an expected value.