### PR TITLE
return html from validation function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.6-dev
+ - return loaded html as `String` from `validate_and_load_static_assets()`
+ - validate response in the order information comes available (status code, headers, title and texts)
+
 ## 0.1.5 July 19, 2021
  - documentation fix, `load_static_elements()` is `async` and requires `.await`
  - update goose dependency to `0.13`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-eggs"
-version = "0.1.5"
+version = "0.1.6-dev"
 authors = ["Jeremy Andrews <jeremy@tag1.com>"]
 edition = "2018"
 description = "Useful functions and structs for writing Goose load tests."


### PR DESCRIPTION
 - return loaded html as `String` from `validate_and_load_static_assets()`
 - validate response in the order information comes available (status code, headers, title and texts)
