### PR TITLE
be more precise when validating title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.7-dev
+ - introduce `get_html_header()` helper, and use in example that validates the title
+
 ## 0.1.6 July 20, 2021
  - return loaded html as `String` from `validate_and_load_static_assets()`
  - validate response in the order information comes available (status code, headers, title and texts)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## 0.1.7-dev
- - introduce `get_html_header()` helper, and use in example that validates the title
+ - introduce `get_html_header()` helper, and invoke from `valid_title()`
+ - introduce `get_title()` helper, and invoke from `valid_title()`
+ - update `valid_title()` to verify that the title contains the specified string (whereas before it tested that it started with the specified string)
 
 ## 0.1.6 July 20, 2021
  - return loaded html as `String` from `validate_and_load_static_assets()`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-eggs"
-version = "0.1.6"
+version = "0.1.7-dev"
 authors = ["Jeremy Andrews <jeremy@tag1.com>"]
 edition = "2018"
 description = "Useful functions and structs for writing Goose load tests."


### PR DESCRIPTION
 - introduce `get_html_header()` helper, and invoke from `valid_title()`
 - introduce `get_title()` helper, and invoke from `valid_title()`
 - update `valid_title()` to verify that the title contains the specified string (whereas before it tested that it started with the specified string)
