### PR TITLE
allow changing of expected title after log in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
  - introduce `get_html_header()` helper, and invoke from `valid_title()`
  - introduce `get_title()` helper, and invoke from `valid_title()`
  - update `valid_title()` to verify that the title contains the specified string (whereas before it tested that it started with the specified string)
+ - change `USER` to `GOOSE_USER` and `PASS` to `GOOSE_PASS` to avoid conflicts with shell defaults
+ - allow override of expected title after user login; rework how `Login` object is built, allowing it to be changed
 
 ## 0.1.6 July 20, 2021
  - return loaded html as `String` from `validate_and_load_static_assets()`

--- a/src/drupal.rs
+++ b/src/drupal.rs
@@ -277,8 +277,10 @@ impl<'a> Login<'a> {
     /// ```rust
     /// use goose_eggs::drupal::Login;
     ///
-    /// let mut login = Login::password("bar");
-    /// login.unwrap().update_username("foo");
+    /// let login =
+    ///     Login::password("bar")
+    ///         .unwrap()
+    ///         .update_username("foo");
     /// ```
     pub fn update_username(&mut self, username: &'a str) {
         self.username = Some(username);
@@ -295,8 +297,10 @@ impl<'a> Login<'a> {
     /// ```rust
     /// use goose_eggs::drupal::Login;
     ///
-    /// let mut login = Login::username("foo");
-    /// login.unwrap().update_password("bar");
+    /// let login =
+    ///     Login::username("foo")
+    ///         .unwrap()
+    ///         .update_password("bar");
     /// ```
     pub fn update_password(&mut self, password: &'a str) {
         self.password = Some(password);
@@ -313,8 +317,10 @@ impl<'a> Login<'a> {
     /// ```rust
     /// use goose_eggs::drupal::Login;
     ///
-    /// let mut login = Login::username_password("foo", "bar");
-    /// login.unwrap().update_username_password("changed-username", "changed-password");
+    /// let login =
+    ///     Login::username_password("foo", "bar")
+    ///         .unwrap()
+    ///         .update_username_password("changed-username", "changed-password");
     /// ```
     pub fn update_username_password(&mut self, username: &'a str, password: &'a str) {
         self.username = Some(username);
@@ -332,8 +338,10 @@ impl<'a> Login<'a> {
     /// ```rust
     /// use goose_eggs::drupal::Login;
     ///
-    /// let mut login = Login::username("foo");
-    /// login.unwrap().update_url("/custom/user/login");
+    /// let login =
+    ///     Login::username("foo")
+    ///         .unwrap()
+    ///         .update_url("/custom/user/login");
     /// ```
     pub fn update_url(&mut self, url: &'a str) {
         self.url = Some(url);
@@ -350,8 +358,10 @@ impl<'a> Login<'a> {
     /// ```rust
     /// use goose_eggs::drupal::Login;
     ///
-    /// let mut login = Login::username("foo");
-    /// login.unwrap().update_title("Custom Title");
+    /// let login =
+    ///     Login::username("foo")
+    ///         .unwrap()
+    ///         .update_title("Custom Title");
     /// ```
     pub fn update_title(&mut self, title: &'a str) {
         self.title = Some(title);
@@ -369,8 +379,10 @@ impl<'a> Login<'a> {
     /// ```rust
     /// use goose_eggs::drupal::Login;
     ///
-    /// let mut login = Login::username_password("foo", "password");
-    /// login.unwrap().update_url_title("/custom/user/login", "Custom Title");
+    /// let login =
+    ///     Login::username_password("foo", "password")
+    ///         .unwrap()
+    ///         .update_url_title("/custom/user/login", "Custom Title");
     /// ```
     pub fn update_url_title(&mut self, url: &'a str, title: &'a str) {
         self.url = Some(url);


### PR DESCRIPTION
 - change `USER` to `GOOSE_USER` and `PASS` to `GOOSE_PASS` to avoid conflicts with shell defaults
 - allow override of expected title after user login; rework how `Login` object is built, allowing it to be changed
