### PR TITLE
validate forms; lazy match in get_form regex to avoid matching multiple forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.8-dev
+ - validate `get_form` and `get_form_value` succeed or throw warn! level log
+ - lazy match in `get_form` regex to avoid matching multiple forms
+
 ## 0.1.7 July 22, 2021
  - introduce `get_html_header()` helper, and invoke from `valid_title()`
  - introduce `get_title()` helper, and invoke from `valid_title()`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-eggs"
-version = "0.1.7"
+version = "0.1.8-dev"
 authors = ["Jeremy Andrews <jeremy@tag1.com>"]
 edition = "2018"
 description = "Useful functions and structs for writing Goose load tests."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1042,7 +1042,7 @@ pub async fn validate_and_load_static_assets<'a>(
                         Some(&html),
                     )?;
                     // Exit as soon as validation fails, to avoid cascades of
-                    // errors whe na page fails to load.
+                    // errors when a page fails to load.
                     return Ok(html);
                 }
                 if let Some(h) = header.value {
@@ -1059,7 +1059,7 @@ pub async fn validate_and_load_static_assets<'a>(
                             Some(&html),
                         )?;
                         // Exit as soon as validation fails, to avoid cascades of
-                        // errors whe na page fails to load.
+                        // errors when a page fails to load.
                         return Ok(html);
                     }
                 }
@@ -1078,7 +1078,7 @@ pub async fn validate_and_load_static_assets<'a>(
                                 Some(&html),
                             )?;
                             // Exit as soon as validation fails, to avoid cascades of
-                            // errors whe na page fails to load.
+                            // errors when a page fails to load.
                             return Ok(html);
                         }
                     }
@@ -1095,7 +1095,7 @@ pub async fn validate_and_load_static_assets<'a>(
                                 Some(&html),
                             )?;
                             // Exit as soon as validation fails, to avoid cascades of
-                            // errors whe na page fails to load.
+                            // errors when a page fails to load.
                             return Ok(html);
                         }
                     }


### PR DESCRIPTION
 - validate `get_form` and `get_form_value` succeed or throw warn! level log
 - lazy match in `get_form` regex to avoid matching multiple forms
