### PR TITLE
escape form element name so regex compiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.10-dev
+ - escape form element name so regex compiles if name includes characters such as `[]`
+
 ## 0.1.9 July 30, 2021
  - introduce drupal-specific `get_form_values` to efficiently load multiple form values
  - allow validation of whether or not request redirected; rework how `Validate` object is built, allowing it to be changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "goose-eggs"
-version = "0.1.9"
+version = "0.1.10-dev"
 authors = ["Jeremy Andrews <jeremy@tag1.com>"]
 edition = "2018"
-description = "Useful functions and structs for writing Goose load tests."
+description = "Helpful in writing Goose load tests."
 homepage = "https://goose.rs"
 documentation = "https://docs.rs/goose-eggs"
 repository = "https://github.com/tag1consulting/goose-eggs"

--- a/src/drupal.rs
+++ b/src/drupal.rs
@@ -86,7 +86,11 @@ pub fn get_form(html: &str, name: &str) -> String {
 /// assert_eq!(&form_build_id, "form-bHZME2HeTuevNWQR5Y4pyP8jcAu2dfbHERwoscwnajM");
 /// ```
 pub fn get_form_value(form_html: &str, name: &str) -> String {
-    let re = Regex::new(&format!(r#"name="{}" value=['"](.*?)['"]"#, name)).unwrap();
+    let re = Regex::new(&format!(
+        r#"name="{}" value=['"](.*?)['"]"#,
+        regex::escape(name)
+    ))
+    .unwrap();
     // Return a specific form value.
     match re.captures(&form_html) {
         Some(v) => v[1].to_string(),


### PR DESCRIPTION
 - escape form element name so regex compiles if name includes characters such as `[]`