### PR TITLE
remove extra unrelated example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.11-dev
+ - remove extra and incorrect cut and paste example for `SearchParams::keys`
+
 ## 0.1.10 August 2, 2021
  - escape form element name so regex compiles if name includes characters such as `[]`
  - introduce drupal-specific `get_encoded_form_values` to efficiently load multiple encoded form values

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-eggs"
-version = "0.1.10"
+version = "0.1.11-dev"
 authors = ["Jeremy Andrews <jeremy@tag1.com>"]
 edition = "2018"
 description = "Helpful in writing Goose load tests."

--- a/src/drupal.rs
+++ b/src/drupal.rs
@@ -832,12 +832,6 @@ impl<'a> SearchParams<'a> {
     ///
     /// # Example
     /// ```rust
-    /// use goose_eggs::drupal::Login;
-    ///
-    /// let _login = Login::username("foo");
-    /// ```
-    /// # Example
-    /// ```rust
     /// use goose_eggs::drupal::SearchParams;
     ///
     /// // Search for "search terms".


### PR DESCRIPTION
 - remove extra and incorrect cut and paste example for `SearchParams::keys`
