### PR TITLE
match head tag that includes other attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.11-dev
  - remove extra and incorrect cut and paste example for `SearchParams::keys`
+ - match headers `<head>` that include other attributes, such as `<head profile="..">`
 
 ## 0.1.10 August 2, 2021
  - escape form element name so regex compiles if name includes characters such as `[]`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,7 +444,7 @@ impl<'a> Header<'a> {
 /// assert!(!html_header.is_none());
 /// ```
 pub fn get_html_header(html: &str) -> Option<String> {
-    let re = Regex::new(r#"<head>(.*?)</head>"#).unwrap();
+    let re = Regex::new(r#"<head(.*?)</head>"#).unwrap();
     // Strip carriage returns to simplify regex.
     let line = html.replace("\n", "");
     // Return the entire html header, a subset of the received html.


### PR DESCRIPTION
 - match headers `<head>` that include other attributes, such as `<head profile="..">`