### PR TITLE
don't borrow references immediately dereferenced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.1.12-dev
+ - clippy cleanups: don't borrow references that are immediately dereferenced by the compiler: https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
 
 ## 0.1.11 August 4, 2021
  - remove extra and incorrect cut and paste example for `SearchParams::keys`

--- a/examples/umami/common.rs
+++ b/examples/umami/common.rs
@@ -393,7 +393,7 @@ pub fn random_words(count: usize, english: bool) -> Vec<String> {
         ];
         let content_type = content_types.choose(&mut rand::thread_rng());
         // Then randomly select a node of this content type.
-        let nodes = get_nodes(&content_type.unwrap());
+        let nodes = get_nodes(content_type.unwrap());
         let page = nodes.choose(&mut rand::thread_rng());
         // Randomly select a word from the title to use in our search.
         let title = if english {
@@ -477,7 +477,7 @@ pub async fn anonymous_contact_form(user: &GooseUser, english: bool) -> GooseTas
                     return user.set_failure(
                         &format!("{}: failed to parse page: {}", goose.request.raw.url, e),
                         &mut goose.request,
-                        Some(&headers),
+                        Some(headers),
                         None,
                     );
                 }

--- a/examples/umami/english.rs
+++ b/examples/umami/english.rs
@@ -94,7 +94,7 @@ pub async fn page_by_nid(user: &GooseUser) -> GooseTaskResult {
     ];
     let content_type = content_types.choose(&mut rand::thread_rng());
     // Then randomly select a node of this content type.
-    let nodes = common::get_nodes(&content_type.unwrap());
+    let nodes = common::get_nodes(content_type.unwrap());
     let page = nodes.choose(&mut rand::thread_rng());
     // Load the page by nid instead of by URL.
     let goose = user

--- a/src/drupal.rs
+++ b/src/drupal.rs
@@ -92,7 +92,7 @@ pub fn get_form_value(form_html: &str, name: &str) -> String {
     ))
     .unwrap();
     // Return a specific form value.
-    match re.captures(&form_html) {
+    match re.captures(form_html) {
         Some(v) => v[1].to_string(),
         None => {
             warn!("form element {} not found", name);
@@ -207,7 +207,7 @@ pub fn get_updated_build_id(form_html: &str, old_build_id: &str) -> String {
     ))
     .unwrap();
     // Return a specific form value.
-    match re.captures(&form_html) {
+    match re.captures(form_html) {
         Some(v) => v[1].to_string(),
         None => {
             warn!("update_build_id not found");
@@ -257,7 +257,7 @@ pub fn get_form_values<'a>(form: &str, elements: &'a [&str]) -> HashMap<&'a str,
 
     // Extract the form elements needed to submit a form.
     for &element in elements {
-        let value = get_form_value(&form, element);
+        let value = get_form_value(form, element);
         form_elements.insert(element, value);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,7 +535,7 @@ pub fn get_title(html: &str) -> Option<String> {
 ///                         return user.set_failure(
 ///                             &format!("{}: title not found: {}", goose.request.raw.url, title),
 ///                             &mut goose.request,
-///                             Some(&headers),
+///                             Some(headers),
 ///                             Some(&html),
 ///                         );
 ///                     }
@@ -544,7 +544,7 @@ pub fn get_title(html: &str) -> Option<String> {
 ///                     return user.set_failure(
 ///                         &format!("{}: failed to parse page: {}", goose.request.raw.url, e),
 ///                         &mut goose.request,
-///                         Some(&headers),
+///                         Some(headers),
 ///                         None,
 ///                     );
 ///                 }
@@ -606,7 +606,7 @@ pub fn valid_title(html: &str, title: &str) -> bool {
 ///                         return user.set_failure(
 ///                             &format!("{}: text not found: {}", goose.request.raw.url, text),
 ///                             &mut goose.request,
-///                             Some(&headers),
+///                             Some(headers),
 ///                             Some(&html),
 ///                         );
 ///                     }
@@ -615,7 +615,7 @@ pub fn valid_title(html: &str, title: &str) -> bool {
 ///                     return user.set_failure(
 ///                         &format!("{}: failed to parse page: {}", goose.request.raw.url, e),
 ///                         &mut goose.request,
-///                         Some(&headers),
+///                         Some(headers),
 ///                         None,
 ///                     );
 ///                 }
@@ -663,7 +663,7 @@ pub fn valid_text(html: &str, text: &str) -> bool {
 ///                 return user.set_failure(
 ///                     &format!("{}: header not found: {}", goose.request.raw.url, "server"),
 ///                     &mut goose.request,
-///                     Some(&headers),
+///                     Some(headers),
 ///                     None,
 ///                 );
 ///             }
@@ -710,7 +710,7 @@ pub fn header_is_set(headers: &HeaderMap, header: &Header) -> bool {
 ///                 return user.set_failure(
 ///                     &format!("{}: server header value not correct: {}", goose.request.raw.url, "nginx"),
 ///                     &mut goose.request,
-///                     Some(&headers),
+///                     Some(headers),
 ///                     None,
 ///                 );
 ///             }
@@ -784,7 +784,7 @@ pub fn valid_header_value(headers: &HeaderMap, header: &Header) -> bool {
 ///                     return user.set_failure(
 ///                         &format!("{}: failed to parse page: {}", goose.request.raw.url, e),
 ///                         &mut goose.request,
-///                         Some(&headers),
+///                         Some(headers),
 ///                         None,
 ///                     );
 ///                 }
@@ -809,7 +809,7 @@ pub async fn load_static_elements(user: &GooseUser, html: &str) {
     // @TODO: parse HTML5 srcset= also
     let image = Regex::new(r#"src="(.*?)""#).unwrap();
     let mut urls = Vec::new();
-    for url in image.captures_iter(&html) {
+    for url in image.captures_iter(html) {
         if url[1].starts_with("/sites") || url[1].starts_with("/core") {
             urls.push(url[1].to_string());
         }
@@ -818,7 +818,7 @@ pub async fn load_static_elements(user: &GooseUser, html: &str) {
     // Use a regular expression to find all href=<foo> in the HTML, where foo
     // is the URL to css assets.
     let css = Regex::new(r#"href="(/sites/default/files/css/.*?)""#).unwrap();
-    for url in css.captures_iter(&html) {
+    for url in css.captures_iter(html) {
         urls.push(url[1].to_string());
     }
 
@@ -876,7 +876,7 @@ pub async fn validate_and_load_static_assets<'a>(
                     } else {
                         format!("{}: redirected unexpectedly", goose.request.raw.url)
                     };
-                    user.set_failure(&error, &mut goose.request, Some(&headers), Some(&html))?;
+                    user.set_failure(&error, &mut goose.request, Some(headers), Some(&html))?;
                     // Exit as soon as validation fails, to avoid cascades of
                     // errors whe na page fails to load.
                     return Ok(html);
@@ -896,7 +896,7 @@ pub async fn validate_and_load_static_assets<'a>(
                             goose.request.raw.url, status, response_status
                         ),
                         &mut goose.request,
-                        Some(&headers),
+                        Some(headers),
                         Some(&html),
                     )?;
                     // Exit as soon as validation fails, to avoid cascades of
@@ -917,7 +917,7 @@ pub async fn validate_and_load_static_assets<'a>(
                             goose.request.raw.url, header
                         ),
                         &mut goose.request,
-                        Some(&headers),
+                        Some(headers),
                         Some(&html),
                     )?;
                     // Exit as soon as validation fails, to avoid cascades of
@@ -934,7 +934,7 @@ pub async fn validate_and_load_static_assets<'a>(
                                 goose.request.raw.url, h
                             ),
                             &mut goose.request,
-                            Some(&headers),
+                            Some(headers),
                             Some(&html),
                         )?;
                         // Exit as soon as validation fails, to avoid cascades of
@@ -949,11 +949,11 @@ pub async fn validate_and_load_static_assets<'a>(
                 Ok(html) => {
                     // Validate title if defined.
                     if let Some(title) = validate.title {
-                        if !valid_title(&html, &title) {
+                        if !valid_title(&html, title) {
                             user.set_failure(
                                 &format!("{}: title not found: {}", goose.request.raw.url, title),
                                 &mut goose.request,
-                                Some(&headers),
+                                Some(headers),
                                 Some(&html),
                             )?;
                             // Exit as soon as validation fails, to avoid cascades of
@@ -970,7 +970,7 @@ pub async fn validate_and_load_static_assets<'a>(
                                     goose.request.raw.url, text
                                 ),
                                 &mut goose.request,
-                                Some(&headers),
+                                Some(headers),
                                 Some(&html),
                             )?;
                             // Exit as soon as validation fails, to avoid cascades of
@@ -985,7 +985,7 @@ pub async fn validate_and_load_static_assets<'a>(
                     user.set_failure(
                         &format!("{}: failed to parse page: {}", goose.request.raw.url, e),
                         &mut goose.request,
-                        Some(&headers),
+                        Some(headers),
                         None,
                     )?;
                     Ok(empty)


### PR DESCRIPTION
  - clippy cleanups: don't borrow references that are immediately dereferenced by the compiler: https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow