### PR TITLE
find forms identified with either `id=` or `data-drupal-selector=`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.2.1-dev
+ - find forms identified with either `id=` or `data-drupal-selector=`
 
 ## 0.2.0 October 5, 2021
  - **API change**: update goose to [0.14](https://github.com/tag1consulting/goose/releases/tag/0.14.0)

--- a/src/drupal.rs
+++ b/src/drupal.rs
@@ -39,7 +39,7 @@ use std::env;
 pub fn get_form(html: &str, name: &str) -> String {
     let re = Regex::new(&format!(
         // Lazy match to avoid matching multiple forms.
-        r#"<form.*?data-drupal-selector="{}".*?>(.*?)</form>"#,
+        r#"<form.*?(data-drupal-selector|id)="{}".*?>(.*?)</form>"#,
         name
     ))
     .unwrap();
@@ -47,7 +47,7 @@ pub fn get_form(html: &str, name: &str) -> String {
     let line = html.replace("\n", "");
     // Return the entire form, a subset of the received html.
     match re.captures(&line) {
-        Some(capture) => capture[1].to_string(),
+        Some(capture) => capture[2].to_string(),
         None => {
             warn!("form {} not found", name);
             "".to_string()


### PR DESCRIPTION
 - use regex or to match `id=` or `data-drupal-selector=` inside `<form>`