### PR TITLE
don't allocate `status` variable unless it's used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.1-dev
  - find forms identified with either `id=` or `data-drupal-selector=`
+ - don't allocate local `status` variable unless it will be used
 
 ## 0.2.0 October 5, 2021
  - **API change**: update goose to [0.14](https://github.com/tag1consulting/goose/releases/tag/0.14.0)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -891,11 +891,11 @@ pub async fn validate_and_load_static_assets<'a>(
             }
 
             // Validate status code if defined.
-            let response_status = response.status();
             if let Some(status) = validate.status {
-                if response_status != status {
+                if response.status() != status {
                     // Get as much as we can from the response for useful debug logging.
                     let headers = &response.headers().clone();
+                    let response_status = &response.status();
                     let html = response.text().await.unwrap_or_else(|_| "".to_string());
                     user.set_failure(
                         &format!(


### PR DESCRIPTION
Don't unnecessarily allocate a copy of status unless it will be used (which only happens if the returned status is different than the expected status, for error reporting).