### PR TITLE
remove Header struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
  - **API change**: introduce `ValidateBuilder` to build `Validate` objects
     o Replaces `Validate::new`, `Validate::status`, `Validate::title`, `Validate::text`, `Validate::texts`, `Validate::title_text`, `Validate::title_texts`, `Validate::header`, `Validate::headers`, `Validate::redirect`, `Validate::update_status`, `Validate::update_title`, `Valudate::update_text`, `Validate::update_texts`, `Validate::update_header`, `Validate::update_header`
     o Builder pattern is: `Validate::builder().status(200).text("foo").redirect(true).build();`
+ - **API change**: remove `Header` struct, instead using a simple (&str, &str) tuple
+    o Removes `Header` and all associated functions
+    o Builder pattern to validate headers is `Validate::builder().header("cache").header_value("x-generator", "Drupal 7").build();`
 
 ## 0.2.0 October 5, 2021
  - **API change**: update goose to [0.14](https://github.com/tag1consulting/goose/releases/tag/0.14.0)


### PR DESCRIPTION
 - **API change**: remove `Header` struct, instead using a simple (&str, &str) tuple
    o Removes `Header` and all associated functions
    o Builder pattern to validate headers is `Validate::builder().header("cache").header_value("x-generator", "Drupal 7").build();`
 - replaces https://github.com/tag1consulting/goose-eggs/pull/41