### PR TITLE
release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.0-dev
+## 0.3.0 October 26, 2021
  - find forms identified with either `id=` or `data-drupal-selector=`
  - **API change**: introduce `SearchParamsBuilder` to build `SearchParams` objects
     o Replaces `SearchParams::keys`, `SearchParams::update_keys`, `SearchParams::update_url`, `SearchParams::update_submit`, `SearchParams::update_title`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-eggs"
-version = "0.3.0-dev"
+version = "0.3.0"
 authors = ["Jeremy Andrews <jeremy@tag1.com>"]
 edition = "2018"
 description = "Helpful in writing Goose load tests."


### PR DESCRIPTION
## 0.3.0 October 26, 2021
 - find forms identified with either `id=` or `data-drupal-selector=`
 - **API change**: introduce `SearchParamsBuilder` to build `SearchParams` objects
    o Replaces `SearchParams::keys`, `SearchParams::update_keys`, `SearchParams::update_url`, `SearchParams::update_submit`, `SearchParams::update_title`
    o Builder pattern is: `SearchParams::builder().keys("foo").url("custom/url").submit("Search").build();`
 - **API change**: introduce `LoginBuilder` to build `Login` objects
    o Replaces `Login::username`, `Login::password`, `Login::username_password`, `Login::url`, `Login::title`, `Login::url_title`, `Login::update_username`, `Login::update_password`, `Login::update_username_password`, `Login::update_url`, `Login::update_title`, `Login::update_url_title`
    o Builder pattern is: `Login::builder().username("username").password("password").url("custom/login/url").build();`
 - **API change**: introduce `ValidateBuilder` to build `Validate` objects
    o Replaces `Validate::new`, `Validate::status`, `Validate::title`, `Validate::text`, `Validate::texts`, `Validate::title_text`, `Validate::title_texts`, `Validate::header`, `Validate::headers`, `Validate::redirect`, `Validate::update_status`, `Validate::update_title`, `Valudate::update_text`, `Validate::update_texts`, `Validate::update_header`, `Validate::update_header`
    o Builder pattern is: `Validate::builder().status(200).text("foo").redirect(true).build();`
 - **API change**: remove `Header` struct, instead using a simple (&str, &str) tuple
    o Removes `Header` and all associated functions
    o Builder pattern to validate headers is `Validate::builder().header("cache").header_value("x-generator", "Drupal 7").build();`