### PR TITLE
Umami Example: Support nids higher than 255 (u32 vs u8)

### DIFF
--- a/examples/umami/common.rs
+++ b/examples/umami/common.rs
@@ -13,7 +13,7 @@ pub enum ContentType {
 /// Details tracked about individual nodes used to run load test and validate
 /// that pages are being correctly loaded.
 pub struct Node<'a> {
-    pub nid: u8,
+    pub nid: u32,
     pub url_en: &'a str,
     pub url_es: &'a str,
     pub title_en: &'a str,


### PR DESCRIPTION
Umami Example: Support nids higher than 255 (u32 vs u8)

See https://github.com/tag1consulting/goose/pull/491