### PR TITLE
release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.4.1-dev
+## 0.4.1 June 16, 2022
  - introduce `validate_page` to validate a page without loading static assets, an alternative to `validate_and_load_static_assets`
 
 ## 0.4.0 May 1, 2022

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-eggs"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Jeremy Andrews <jeremy@tag1.com>"]
 edition = "2018"
 description = "Helpful in writing Goose load tests."


### PR DESCRIPTION
## 0.4.1 June 16, 2022
 - introduce `validate_page` to validate a page without loading static assets, an alternative to `validate_and_load_static_assets`
