### PR TITLE
Update goose to 0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## 0.4.2-dev
+## 0.5.0-dev
  - add support for building with [rustls](https://docs.rs/rustls) via the `rustls-tls` feature
+ - **API change**: update goose to [0.17](https://github.com/tag1consulting/goose/releases/tag/0.17.0)
+ - **API change**: Box `TransactionError` to avoid over-allocating memory on the stack (to match goose 0.17.0)
 
 ## 0.4.1 June 16, 2022
  - introduce `validate_page` to validate a page without loading static assets, an alternative to `validate_and_load_static_assets`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-eggs"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Jeremy Andrews <jeremy@tag1.com>"]
 edition = "2018"
 description = "Helpful in writing Goose load tests."
@@ -12,7 +12,7 @@ keywords = ["loadtesting", "performance", "web"]
 license = "Apache-2.0"
 
 [dependencies]
-goose = { version = "0.16", default-features = false }
+goose = { version = "0.17", default-features = false }
 log = "0.4"
 rand = "0.8"
 regex = "1.5"

--- a/src/drupal.rs
+++ b/src/drupal.rs
@@ -576,7 +576,10 @@ impl<'a> LoginBuilder<'a> {
 /// }
 ///
 /// ```
-pub async fn log_in(user: &mut GooseUser, login: &Login<'_>) -> Result<String, TransactionError> {
+pub async fn log_in(
+    user: &mut GooseUser,
+    login: &Login<'_>,
+) -> Result<String, Box<TransactionError>> {
     // Use the `GOOSE_USER` environment variable if it's set, otherwise use the specified
     // (or default) login username.
     let username = env::var("GOOSE_USER").unwrap_or_else(|_| login.username.to_string());
@@ -1016,7 +1019,7 @@ impl<'a> SearchParamsBuilder<'a> {
 pub async fn search<'a>(
     user: &mut GooseUser,
     params: &'a SearchParams<'a>,
-) -> Result<String, TransactionError> {
+) -> Result<String, Box<TransactionError>> {
     // Load the search page.
     let goose = user.get(params.url).await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -789,7 +789,7 @@ pub async fn validate_page<'a>(
     user: &mut GooseUser,
     mut goose: GooseResponse,
     validate: &'a Validate<'a>,
-) -> Result<String, TransactionError> {
+) -> Result<String, Box<TransactionError>> {
     let empty = "".to_string();
     match goose.response {
         Ok(response) => {
@@ -968,7 +968,7 @@ pub async fn validate_and_load_static_assets<'a>(
     user: &mut GooseUser,
     goose: GooseResponse,
     validate: &'a Validate<'a>,
-) -> Result<String, TransactionError> {
+) -> Result<String, Box<TransactionError>> {
     match validate_page(user, goose, validate).await {
         Ok(html) => {
             load_static_elements(user, &html).await;


### PR DESCRIPTION
Hi, I've updated the goose dependency to 0.17. `TransactionError` is now boxed to match the change in goose, and I've bumped the version number up to 0.5.0 as this is a breaking change.