### PR TITLE
Log static assets by type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - add support for building with [rustls](https://docs.rs/rustls) via the `rustls-tls` feature
  - **API change**: update goose to [0.17](https://github.com/tag1consulting/goose/releases/tag/0.17.0)
  - **API change**: Box `TransactionError` to avoid over-allocating memory on the stack (to match goose 0.17.0)
+ - `load_static_elements` logs asset loading in multiple groups: css, js and img
 
 ## 0.4.1 June 16, 2022
  - introduce `validate_page` to validate a page without loading static assets, an alternative to `validate_and_load_static_assets`


### PR DESCRIPTION
With this PR the static assets detected by `load_static_elements` get logged by type: css, img or js.

This is how the new output looks like:
```
 ------------------------------------------------------------------------------
 Name                     |    Avg (ms) |        Min |         Max |     Median
 ------------------------------------------------------------------------------
 GET static asset: css    |       15.40 |          2 |         287 |         10
 GET static asset: img    |       42.83 |          3 |         398 |         17
 GET static asset: js     |        4.97 |          2 |         120 |          3
 -------------------------+-------------+------------+-------------+-----------
```

If we don't want to see this behavior by default, we could also create a new function `load_static_elements_by_type` and leave the existing one unchanged.