### PR TITLE
don't hard code form_id, respect validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.5.1-dev
+ - in `drupal::log_in`, allow `form_id` other than the default of `user_login_form`
 
 ## 0.5.0 January 24, 2023
  - add support for building with [rustls](https://docs.rs/rustls) via the `rustls-tls` feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
 ## 0.5.1-dev
- - in `drupal::log_in`, allow `form_id` other than the default of `user_login_form`
+ - in `drupal::log_in`
+    o allow `form_id` other than the default of `user_login_form`
+    o properly validate status code if configured
+    o propery post login to configured path
 
 ## 0.5.0 January 24, 2023
  - add support for building with [rustls](https://docs.rs/rustls) via the `rustls-tls` feature

--- a/src/drupal.rs
+++ b/src/drupal.rs
@@ -39,8 +39,7 @@ use std::env;
 pub fn get_form(html: &str, name: &str) -> String {
     let re = Regex::new(&format!(
         // Lazy match to avoid matching multiple forms.
-        r#"<form.*?(data-drupal-selector|id)="{}".*?>(.*?)</form>"#,
-        name
+        r#"<form.*?(data-drupal-selector|id)="{name}".*?>(.*?)</form>"#,
     ))
     .unwrap();
     // Strip carriage returns to simplify regex.

--- a/src/drupal.rs
+++ b/src/drupal.rs
@@ -654,7 +654,7 @@ pub async fn log_in(
         ("form_id", &form_id),
         ("op", &"Log+in".to_string()),
     ];
-    let mut logged_in_user = user.post_form("/user/login", &params).await?;
+    let mut logged_in_user = user.post_form(login.url, &params).await?;
 
     // A successful log in is redirected.
     if !logged_in_user.request.redirected {

--- a/src/drupal.rs
+++ b/src/drupal.rs
@@ -632,12 +632,26 @@ pub async fn log_in(
         return Ok("".to_string());
     }
 
+    // Also extract the form_id (defaults to `user_login_form`).
+    let form_id = get_form_value(&login_form, "form_id");
+    if form_id.is_empty() {
+        user.set_failure(
+            &format!("{}: no form_id on page", login.url),
+            &mut login_request,
+            None,
+            Some(&login_form),
+        )?;
+        // Return an empty string as log-in failed. Enable the debug log to
+        // determine why.
+        return Ok("".to_string());
+    }
+
     // Build log in form with username and password from environment.
     let params = [
         ("name", &username),
         ("pass", &password),
         ("form_build_id", &form_build_id),
-        ("form_id", &"user_login_form".to_string()),
+        ("form_id", &form_id),
         ("op", &"Log+in".to_string()),
     ];
     let mut logged_in_user = user.post_form("/user/login", &params).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -733,7 +733,7 @@ pub async fn load_static_elements(user: &mut GooseUser, html: &str) {
     // Use a case-insensitive regular expression to find all src=<foo> in the html, where
     // <foo> is the URL to local image and js assets.
     // @TODO: parse HTML5 srcset= also
-    let src_elements = Regex::new(format!(r#"(?i)src="(({}|/).*?)""#, base_url).as_str()).unwrap();
+    let src_elements = Regex::new(format!(r#"(?i)src="(({base_url}|/).*?)""#).as_str()).unwrap();
     for url in src_elements.captures_iter(html) {
         let is_js = url[1].to_string().contains(".js");
         let resource_type = if is_js { "js" } else { "img" };
@@ -744,7 +744,7 @@ pub async fn load_static_elements(user: &mut GooseUser, html: &str) {
 
     // Use a case-insensitive regular expression to find all href=<foo> in the html, where
     // <foo> is the URL to local css assets.
-    let css = Regex::new(format!(r#"(?i)href="(({}|/).*?\.css.*?)""#, base_url).as_str()).unwrap();
+    let css = Regex::new(format!(r#"(?i)href="(({base_url}|/).*?\.css.*?)""#).as_str()).unwrap();
     for url in css.captures_iter(html) {
         let _ = user.get_named(&url[1], "static asset: css").await;
     }


### PR DESCRIPTION
 - in `drupal::log_in`, allow `form_id` other than the default of `user_login_form`, respect form_path and status code validation

Prior to this change:
 - a custom log in form may have an alternative form_id (such as `user_login_block`) causing log in to fail
 - a custom log in path may require the form to be posted somewhere other than Drupal's default of `/user/login`
 - a non-200 response may be expected when loading the login form, but Goose's default response validation would generate an error