### PR TITLE
Match absolute and relative paths with and without leading slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.5.2-dev
+ - match "http://example.com/example.css", "/path/to/example.css", and "path/to/example.css" formatted paths for all types of static assets
 
 ## 0.5.1 January 28, 2023
  - in `drupal::log_in`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "Apache-2.0"
 
 [dependencies]
 goose = { version = "0.17", default-features = false }
+http = "0.2"
 log = "0.4"
 rand = "0.8"
 regex = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,11 @@ log = "0.4"
 rand = "0.8"
 regex = "1.5"
 reqwest = { version = "0.11", default-features = false }
-tokio = "1"
+tokio = { version = "1", features = [ "macros" ] }
 
 [features]
 default = ["goose/default", "reqwest/default-tls"]
 rustls-tls = ["goose/rustls-tls", "reqwest/rustls-tls"]
+
+[dev-dependencies]
+gumdrop = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1055,9 +1055,11 @@ mod tests {
         const HTML: &str = r#"<!DOCTYPE html>
         <html>
         <body>
-            <!-- 3 valid CSS paths -->
+            <!-- 4 valid CSS paths -->
                 <!-- valid local http path including host -->
                 <link href="http://example.com/example.css" rel="stylesheet" />
+                <!-- valid local http path including host and query parameter -->
+                <link href="http://example.com/example.css?version=abc123" rel="stylesheet" />
                 <!-- invalid http path on different subdomain -->
                 <link href="http://other.example.com/example.css" rel="stylesheet" />
                 <!-- invalid http path on different domain -->
@@ -1069,7 +1071,7 @@ mod tests {
                 <!-- valid absolute path -->
                 <link href="/path/to/example.css" rel="stylesheet" />
             
-            <!-- 3 valid image paths -->
+            <!-- 4 valid image paths -->
                 <!-- valid local http path including host -->
                 <img src="http://example.com/example.jpg" alt="example image" width="10" height="10"> 
                 <!-- invalid http path on different subdomain -->
@@ -1079,7 +1081,9 @@ mod tests {
                 <!-- valid relative path -->
                 <img src="path/to/example.gif" alt="example image" />
                 <!-- valid absolute path -->
-                <img src="/path/to/example." alt="example image" />
+                <img src="/path/to/example.png" alt="example image" />
+                <!-- valid absolute path with query parameter -->
+                <img src="/path/to/example.jpg?itok=Q8u7GC4u" alt="example image" />
 
             <!-- 3 valid JS paths -->
                 <!-- valid local http path including host -->
@@ -1099,27 +1103,29 @@ mod tests {
         let mut user =
             GooseUser::new(0, "".to_string(), base_url, &configuration, 0, None).unwrap();
         let urls = get_css_elements(&mut user, HTML).await;
-        if urls.len() != 3 {
+        if urls.len() != 4 {
             eprintln!(
                 "expected matches: {:#?}",
                 vec![
                     "http://example.com/example.css",
+                    "http://example.com/example.css?version=abc123",
                     "path/to/example.css",
                     "/path/to/example.css",
                 ]
             );
             eprintln!("actual matches: {:#?}", urls);
         }
-        assert_eq!(urls.len(), 3);
+        assert_eq!(urls.len(), 4);
 
         let urls = get_src_elements(&mut user, HTML).await;
-        if urls.len() != 6 {
+        if urls.len() != 7 {
             eprintln!(
                 "expected matches: {:#?}",
                 vec![
                     "http://example.com/example.jpg",
                     "path/to/example.gif",
-                    "/path/to/example.",
+                    "/path/to/example.png",
+                    "/path/to/example.jpg?itok=Q8u7GC4u",
                     "http://example.com/example.js",
                     "path/to/example.js",
                     "/path/to/example.js",
@@ -1127,6 +1133,6 @@ mod tests {
             );
             eprintln!("actual matches: {:#?}", urls);
         }
-        assert_eq!(urls.len(), 6);
+        assert_eq!(urls.len(), 7);
     }
 }


### PR DESCRIPTION
 - use `http` crate to validate uris scraped from page
 - match "http://example.com/example.css", "/example.css" and "example.css" formatted paths
 - add test coverage to prevent future regressions
 - closes https://github.com/tag1consulting/goose-eggs/issues/56