### PR TITLE
add inverse validation functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.5.2-dev
  - match "http://example.com/example.css", "/path/to/example.css", and "path/to/example.css" formatted paths for all types of static assets
- - introduce `not_status()`, `not_title()`, `not_text()`, `not_texts()`
+ - introduce `not_status()`, `not_title()`, `not_text()`, `not_texts()`, `not_header()`, and `not_header_value()`
 
 ## 0.5.1 January 28, 2023
  - in `drupal::log_in`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.5.2-dev
  - match "http://example.com/example.css", "/path/to/example.css", and "path/to/example.css" formatted paths for all types of static assets
- - introduce `not_status()`, `not_title()`
+ - introduce `not_status()`, `not_title()`, `not_text()`, `not_texts()`
 
 ## 0.5.1 January 28, 2023
  - in `drupal::log_in`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.5.2-dev
  - match "http://example.com/example.css", "/path/to/example.css", and "path/to/example.css" formatted paths for all types of static assets
+ - introduce `not_status()`, `not_title()`
 
 ## 0.5.1 January 28, 2023
  - in `drupal::log_in`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ rustls-tls = ["goose/rustls-tls", "reqwest/rustls-tls"]
 
 [dev-dependencies]
 gumdrop = "0.8"
+httpmock = "0.6"

--- a/src/drupal.rs
+++ b/src/drupal.rs
@@ -602,7 +602,7 @@ pub async fn log_in(
         // Build request manually if validating a specific status code.
         let goose_request = GooseRequest::builder()
             .path(login.url)
-            .expect_status_code(validate.status.unwrap())
+            .expect_status_code(validate.status.unwrap().1)
             .build();
         user.request(goose_request).await.unwrap()
     } else {
@@ -680,7 +680,7 @@ pub async fn log_in(
         let goose_request = GooseRequest::builder()
             .path(login.url)
             .method(GooseMethod::Post)
-            .expect_status_code(validate.status.unwrap())
+            .expect_status_code(validate.status.unwrap().1)
             .set_request_builder(reqwest_request_builder.form(&params))
             .build();
         user.request(goose_request).await.unwrap()

--- a/src/drupal.rs
+++ b/src/drupal.rs
@@ -598,11 +598,11 @@ pub async fn log_in(
     };
 
     // Load the log in page.
-    let goose = if validate.status.is_some() {
+    let goose = if let Some(validate_status) = validate.status.as_ref() {
         // Build request manually if validating a specific status code.
         let goose_request = GooseRequest::builder()
             .path(login.url)
-            .expect_status_code(validate.status.unwrap().1)
+            .expect_status_code(validate_status.status_code)
             .build();
         user.request(goose_request).await.unwrap()
     } else {
@@ -672,7 +672,7 @@ pub async fn log_in(
         ("op", &"Log+in".to_string()),
     ];
     // Post the log in form.
-    let mut logged_in_user = if validate.status.is_some() {
+    let mut logged_in_user = if let Some(validate_status) = validate.status.as_ref() {
         // Build request manually if validating a specific status code.
         let url = user.build_url(login.url)?;
         // A request builder object is necessary to post a form.
@@ -680,7 +680,7 @@ pub async fn log_in(
         let goose_request = GooseRequest::builder()
             .path(login.url)
             .method(GooseMethod::Post)
-            .expect_status_code(validate.status.unwrap().1)
+            .expect_status_code(validate_status.status_code)
             .set_request_builder(reqwest_request_builder.form(&params))
             .build();
         user.request(goose_request).await.unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub mod text;
 
 /// Validate that the status code is equal or not equal to a specified value.
 #[derive(Clone, Debug)]
-pub struct ValidateStatus {
+struct ValidateStatus {
     // Whether to validate that the status code is equal or not equal to the specified value.
     equals: bool,
     // Status code to validate
@@ -30,7 +30,7 @@ pub struct ValidateStatus {
 
 /// Validate that the page title is equal or not equal to a specified value.
 #[derive(Clone, Debug)]
-pub struct ValidateTitle<'a> {
+struct ValidateTitle<'a> {
     // Whether to validate that the title contains or does not contain the specified value.
     exists: bool,
     // Title text to validate
@@ -39,7 +39,7 @@ pub struct ValidateTitle<'a> {
 
 /// Validate that the specified text exists or does not exist on the page.
 #[derive(Clone, Debug)]
-pub struct ValidateText<'a> {
+struct ValidateText<'a> {
     // Whether to validate that the page contains or does not contain the specified text.
     exists: bool,
     // Text to validate
@@ -48,7 +48,7 @@ pub struct ValidateText<'a> {
 
 /// Validate that the specified header exists or does not exist, optionally containing a specified value.
 #[derive(Clone, Debug)]
-pub struct ValidateHeader<'a> {
+struct ValidateHeader<'a> {
     // Whether to validate that the page contains or does not contain the specified header.
     exists: bool,
     // Header to validate

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -1,0 +1,214 @@
+use gumdrop::Options;
+use httpmock::{Method::GET, MockServer};
+
+use goose::config::GooseConfiguration;
+use goose::prelude::*;
+
+// Paths used in load tests performed during these tests.
+const PATH: &str = "/one";
+
+const HTML: &str = r#"
+<!DOCTYPE html>
+<head>
+  <title>Title 1234ABCD</title>
+</head>
+<body>
+  <p>Test text on the page.</p>
+</body>
+"#;
+
+// Test transaction.
+pub async fn get_path_valid(user: &mut GooseUser) -> TransactionResult {
+    let goose = user.get(PATH).await?;
+    goose_eggs::validate_and_load_static_assets(
+        user,
+        goose,
+        &goose_eggs::Validate::builder()
+            .title("1234ABCD")
+            .not_title("Example")
+            .text("Test text")
+            .text("<!DOCTYPE html>")
+            .not_text("<!DocType html>")
+            .header_value("foo", "bar")
+            .not_header("bar")
+            .build(),
+    )
+    .await?;
+
+    Ok(())
+}
+
+// Build appropriate configuration for these tests.
+fn build_configuration(server: &MockServer) -> GooseConfiguration {
+    // Declare server_url so its lifetime is sufficient when needed.
+    let server_url = server.base_url();
+
+    // Common elements in all our tests.
+    let configuration = vec![
+        "--users",
+        "1",
+        "--hatch-rate",
+        "4",
+        "--iterations",
+        "1",
+        "--host",
+        &server_url,
+        "--co-mitigation",
+        "disabled",
+        "--quiet",
+    ];
+
+    // Parse these options to generate a GooseConfiguration.
+    GooseConfiguration::parse_args_default(&configuration)
+        .expect("failed to parse options and generate a configuration")
+}
+
+async fn run_load_test(server: &MockServer) -> GooseMetrics {
+    // Run the Goose Attack.
+    let goose_metrics = build_load_test(
+        build_configuration(server),
+        vec![scenario!("LoadTest").register_transaction(transaction!(get_path_valid))],
+        None,
+        None,
+    )
+    .execute()
+    .await
+    .unwrap();
+
+    // Load test always launches 1 user and makes 1 request.
+    assert!(goose_metrics.total_users == 1);
+    // Provide debug if this fails.
+    if goose_metrics.requests.len() != 1 {
+        println!("EXPECTED ONE REQUEST: {:#?}", goose_metrics.requests);
+    }
+    assert!(goose_metrics.requests.len() == 1);
+
+    goose_metrics
+}
+
+// Create a GooseAttack object from the configuration, Scenarios, and optional start and
+// stop Transactions.
+#[allow(dead_code)]
+pub fn build_load_test(
+    configuration: GooseConfiguration,
+    scenarios: Vec<Scenario>,
+    start_transaction: Option<&Transaction>,
+    stop_transaction: Option<&Transaction>,
+) -> GooseAttack {
+    // First set up the common base configuration.
+    let mut goose = crate::GooseAttack::initialize_with_config(configuration).unwrap();
+
+    for scenario in scenarios {
+        goose = goose.register_scenario(scenario.clone());
+    }
+
+    if let Some(transaction) = start_transaction {
+        goose = goose.test_start(transaction.clone());
+    }
+
+    if let Some(transaction) = stop_transaction {
+        goose = goose.test_stop(transaction.clone());
+    }
+
+    goose
+}
+
+#[tokio::test]
+// Make a single request and validate everything.
+async fn test_valid() {
+    // Start the mock server.
+    let server = MockServer::start();
+
+    let mock_endpoint =
+        // Set up PATH, store in vector at KEY_ONE.
+        server.mock(|when, then| {
+            when.method(GET).path(PATH);
+            then.status(200)
+                .header("foo", "bar")
+                .body(HTML);
+        });
+
+    let goose_metrics = run_load_test(&server).await;
+    assert!(mock_endpoint.hits() == 1);
+
+    // Provide debug if this fails.
+    if !goose_metrics.errors.is_empty() {
+        println!("UNEXPECTED ERRORS: {:#?}", goose_metrics.errors);
+    }
+    assert!(goose_metrics.errors.is_empty());
+}
+
+#[tokio::test]
+// Make a single request and confirm detection of invalid status code.
+async fn test_invalid_status() {
+    // Start the mock server.
+    let server = MockServer::start();
+
+    let mock_endpoint =
+        // Set up PATH, store in vector at KEY_ONE.
+        server.mock(|when, then| {
+            when.method(GET).path(PATH);
+            then.status(404)
+                .header("foo", "bar")
+                .body(HTML);
+        });
+
+    let goose_metrics = run_load_test(&server).await;
+    assert!(mock_endpoint.hits() == 1);
+
+    // Provide debug if this fails.
+    if goose_metrics.errors.len() != 1 {
+        println!("EXPECTED ONE ERRORS: {:#?}", goose_metrics.errors);
+    }
+    assert!(goose_metrics.errors.len() == 1);
+}
+
+#[tokio::test]
+// Make a single request and confirm detection of invalid header.
+async fn test_invalid_header() {
+    // Start the mock server.
+    let server = MockServer::start();
+
+    let mock_endpoint =
+        // Set up PATH, store in vector at KEY_ONE.
+        server.mock(|when, then| {
+            when.method(GET).path(PATH);
+            then.status(200)
+                .header("bar", "foo")
+                .body(HTML);
+        });
+
+    let goose_metrics = run_load_test(&server).await;
+    assert!(mock_endpoint.hits() == 1);
+
+    // Provide debug if this fails.
+    if goose_metrics.errors.len() != 1 {
+        println!("EXPECTED ONE ERRORS: {:#?}", goose_metrics.errors);
+    }
+    assert!(goose_metrics.errors.len() == 1);
+}
+
+#[tokio::test]
+// Make a single request and confirm detection of invalid header value.
+async fn test_invalid_header_value() {
+    // Start the mock server.
+    let server = MockServer::start();
+
+    let mock_endpoint =
+        // Set up PATH, store in vector at KEY_ONE.
+        server.mock(|when, then| {
+            when.method(GET).path(PATH);
+            then.status(200)
+                .header("foo", "invalid")
+                .body(HTML);
+        });
+
+    let goose_metrics = run_load_test(&server).await;
+    assert!(mock_endpoint.hits() == 1);
+
+    // Provide debug if this fails.
+    if goose_metrics.errors.len() != 1 {
+        println!("EXPECTED ONE ERRORS: {:#?}", goose_metrics.errors);
+    }
+    assert!(goose_metrics.errors.len() == 1);
+}


### PR DESCRIPTION
 - closes https://github.com/tag1consulting/goose-eggs/issues/55
 - introduces `not_status()` to confirm status code is not returned
 - introduces `not_title()` to confirm text is not in the title of the page
 - introduces `not_text()` and `not_texts()` to confirm text is not on the page
 - introduces `not_header()` and `not_header_value()` to confirm header and/or header value is not returned
 - @TODO: add test coverage