### PR TITLE
Decode the HTML before loading static assets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "Apache-2.0"
 
 [dependencies]
 goose = { version = "0.17", default-features = false }
+html-escape = "0.2"
 http = "0.2"
 log = "0.4"
 rand = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -993,7 +993,7 @@ pub async fn get_src_elements(user: &mut GooseUser, html: &str) -> Vec<String> {
     // @TODO: parse HTML5 srcset= also
     let src_elements = Regex::new(r#"(?i)src="(.*?)""#).unwrap();
     let mut elements: Vec<String> = Vec::new();
-    for url in src_elements.captures_iter(html) {
+    for url in src_elements.captures_iter(html_escape::decode_html_entities(html).as_ref()) {
         if valid_local_uri(user, &url[1]) {
             elements.push(url[1].to_string());
         }
@@ -1010,7 +1010,7 @@ pub async fn get_css_elements(user: &mut GooseUser, html: &str) -> Vec<String> {
     // <foo> is the URL to local css assets.
     let css = Regex::new(r#"(?i)href="(.*?\.css.*?)""#).unwrap();
     let mut elements: Vec<String> = Vec::new();
-    for url in css.captures_iter(html) {
+    for url in css.captures_iter(html_escape::decode_html_entities(html).as_ref()) {
         if valid_local_uri(user, &url[1]) {
             elements.push(url[1].to_string());
         }

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -1,0 +1,53 @@
+use gumdrop::Options;
+use httpmock::{Method::GET, MockServer};
+
+use goose::config::GooseConfiguration;
+use goose::goose::get_base_url;
+use goose::metrics::GooseCoordinatedOmissionMitigation::Disabled;
+use goose::prelude::*;
+use goose_eggs::load_static_elements;
+
+#[tokio::test]
+// Loads static elements and checks that characters are decoded properly.
+async fn test_html_decoding() {
+    let html: &str = r#"
+        <!DOCTYPE html>
+        <head>
+          <!-- Check that encoded paths are decoded properly -->
+          <script type="text/javascript" src="/test1.js?foo=1&amp;bar=2"></script>
+          <!-- Check that decoded paths still work -->
+          <script type="text/javascript" src="/test2.js?foo=1&bar=2"></script>
+          <title>Title 1234ABCD</title>
+        </head>
+        <body>
+          <p>Test text on the page.</p>
+        </body>
+        "#;
+
+    let server = MockServer::start();
+
+    let mock_endpoint1 = server.mock(|when, then| {
+        when.method(GET)
+            .path("/test1.js")
+            .query_param("foo", "1")
+            .query_param("bar", "2");
+        then.status(200).body("test");
+    });
+    let mock_endpoint2 = server.mock(|when, then| {
+        when.method(GET)
+            .path("/test2.js")
+            .query_param("foo", "1")
+            .query_param("bar", "2");
+        then.status(200).body("test");
+    });
+
+    let config: Vec<&str> = vec![];
+    let mut configuration = GooseConfiguration::parse_args_default(&config).unwrap();
+    configuration.co_mitigation = Some(Disabled);
+    let base_url = get_base_url(Some(server.base_url()), None, None).unwrap();
+    let mut user = GooseUser::new(0, "".to_string(), base_url, &configuration, 0, None).unwrap();
+
+    load_static_elements(&mut user, html).await;
+    assert_eq!(mock_endpoint1.hits(), 1);
+    assert_eq!(mock_endpoint2.hits(), 1);
+}


### PR DESCRIPTION
With this PR, goose-eggs will decode the HTML before trying to detect and load static assets from it. 

Right now, it just supports the `&amp;` -> `&` decoding.

Without this PR, goose might making requests with encoded ampersand symbols, which could cause servers to return a `4xx` response. At least that's what happened in one of my loadtests; I was testing a Drupal 10.1 site that aggregates assets which then get included into the page with many query parameters.

You can apply the following diff if you wish to see the new failing test:
```diff
diff --git a/src/lib.rs b/src/lib.rs
index de87860..1053b7e 100644
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -985,7 +985,7 @@ fn valid_local_uri(user: &mut GooseUser, uri: &str) -> bool {
 
 /// Decodes the HTML. Currently it just decodes the encoded ampersand character.
 fn decode_html(html: &str) -> String {
-    html.replace("&amp;", "&")
+    html.to_string()
 }
 
 /// Extract all local static elements defined with a `src=` tag from the the provided html.

```