### PR TITLE
Fix clippy

### DIFF
--- a/examples/umami/common.rs
+++ b/examples/umami/common.rs
@@ -28,7 +28,7 @@ pub struct Term<'a> {
 }
 
 /// Returns a vector of all nodes of a specified content type.
-pub fn get_nodes(content_type: &ContentType) -> Vec<Node> {
+pub fn get_nodes(content_type: &ContentType) -> Vec<Node<'_>> {
     match content_type {
         ContentType::Article => {
             vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -750,9 +750,9 @@ pub fn get_title(html: &str) -> Option<String> {
 /// ```
 pub fn valid_title(html: &str, title: &str) -> bool {
     // Extract the HTML header from the provided html.
-    let html_header = get_html_header(html).map_or_else(|| "".to_string(), |h| h);
+    let html_header = get_html_header(html).unwrap_or_default();
     // Next extract the title from the HTML header.
-    let html_title = get_title(&html_header).map_or_else(|| "".to_string(), |t| t);
+    let html_title = get_title(&html_header).unwrap_or_default();
     // Finally, confirm that the title contains the expected text.
     html_title
         .to_ascii_lowercase()


### PR DESCRIPTION
This lint was added in 1.89: https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint

This clippy warning in 1.92: https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#unnecessary_option_map_or_else